### PR TITLE
manual cultivation confirmation

### DIFF
--- a/xianxiacraft/xianxiacraft/QiManagers/ManualManager.java
+++ b/xianxiacraft/xianxiacraft/QiManagers/ManualManager.java
@@ -4,9 +4,11 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -14,6 +16,7 @@ import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
 import xianxiacraft.xianxiacraft.XianxiaCraft;
 import xianxiacraft.xianxiacraft.handlers.Manuals.*;
+import xianxiacraft.xianxiacraft.util.ChatUtils;
 
 import java.io.File;
 import java.io.FileReader;
@@ -97,7 +100,12 @@ public class ManualManager implements Listener {
     //remember to add the update perm thing
     @EventHandler
     public void onManualChange(PlayerInteractEvent event) {
-        ItemStack itemInHand = event.getPlayer().getInventory().getItemInMainHand();
+
+        if (event.getHand() == EquipmentSlot.OFF_HAND) return;
+
+        Player p = event.getPlayer();
+
+        ItemStack itemInHand = p.getInventory().getItemInMainHand();
 
         // Check if the item in hand is a written book
         if (itemInHand.getType() == Material.WRITTEN_BOOK) {
@@ -110,41 +118,51 @@ public class ManualManager implements Listener {
 
                 // Check if the book title matches a specific technique manual
                 assert bookAuthor != null;
-                if(bookAuthor.equals("Spellslot")){
+                if (bookAuthor.equals("Spellslot")) {
+
                     assert bookTitle != null;
-                    final Player p = event.getPlayer();
-                    if(!(bookTitle.equals(manualsMap.get(p.getUniqueId())))){
+                    if (!(bookTitle.equals(manualsMap.get(p.getUniqueId())))) {
 
-                        setPunchBool(p,false);
-                        setMoveBool(p,false);
-
-                        sugarFiendQiMove(p,false);
-                        fattyManualQiMove(p,false);
-                        fungalManualQiMove(p,false);
-
-
-                        setMineBool(p,false);
-                        setAuraBool(p,false);
-                        setFlyBool(p,false);
-
-                        p.setAllowFlight(false);
-                        p.setFlySpeed(0.1f);
-
-
-                        manualsMap.put(p.getUniqueId(),bookTitle);
-                        PointManager.setPoints(p,1);
-                        QiManager.setQi(p,0);
-                        p.sendMessage(ChatColor.GOLD + "Cultivation Manual changed to " + bookTitle + ".\nCultivation has been reset.");
-                        //set all technique commands to false
-
-                        updateScoreboard(p);
-
-                        // Prevent the book from being opened when right-clicked on first try
+                        ChatUtils.handleManualChange(event);
                         event.setCancelled(true);
                     }
                 }
-
             }
+        }
+    }
+
+    public static void accept(Player p) {
+
+        ItemStack itemInHand = p.getInventory().getItemInMainHand();
+        BookMeta bookMeta = itemInHand != null ? (BookMeta) itemInHand.getItemMeta() : null;
+        String bookAuthor = bookMeta != null ? bookMeta.getAuthor() : null;
+        String bookTitle = bookMeta != null ? bookMeta.getTitle() : null;
+
+        if(itemInHand != null && bookMeta != null && bookAuthor != null && bookAuthor.equals("Spellslot") && bookTitle != null && !(bookTitle.equals(manualsMap.get(p.getUniqueId())))) {
+
+            setPunchBool(p, false);
+            setMoveBool(p, false);
+
+            sugarFiendQiMove(p, false);
+            fattyManualQiMove(p, false);
+            fungalManualQiMove(p, false);
+
+
+            setMineBool(p, false);
+            setAuraBool(p, false);
+            setFlyBool(p, false);
+
+            p.setAllowFlight(false);
+            p.setFlySpeed(0.1f);
+
+
+            manualsMap.put(p.getUniqueId(), bookTitle);
+            PointManager.setPoints(p, 1);
+            QiManager.setQi(p, 0);
+            p.sendMessage(ChatColor.GOLD + "Cultivation Manual changed to " + bookTitle + ".\nCultivation has been reset.");
+            //set all technique commands to false
+
+            updateScoreboard(p);
         }
     }
 

--- a/xianxiacraft/xianxiacraft/XianxiaCraft.java
+++ b/xianxiacraft/xianxiacraft/XianxiaCraft.java
@@ -19,6 +19,8 @@ import xianxiacraft.xianxiacraft.commands.OperatorCommands;
 import xianxiacraft.xianxiacraft.handlers.Manuals.*;
 import xianxiacraft.xianxiacraft.util.ManualItems;
 
+import net.kyori.adventure.platform.bukkit.BukkitAudiences;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -40,6 +42,7 @@ public final class XianxiaCraft extends JavaPlugin {
     PointManager pointManager;
     ManualManager manualManager;
     QiManager qiManager;
+    private static BukkitAudiences adventure;
 
     @Override
     public void onEnable() {
@@ -52,6 +55,8 @@ public final class XianxiaCraft extends JavaPlugin {
 
         qiManager = new QiManager(this);
         qiManager.loadQiData();
+
+        adventure = BukkitAudiences.create(this);
 
         new ScoreboardManager1(this);
         new PointHandler(this);
@@ -71,6 +76,7 @@ public final class XianxiaCraft extends JavaPlugin {
         Objects.requireNonNull(getCommand("detonate")).setExecutor(cultPassiveCommandExecutor);
         Objects.requireNonNull(getCommand("qiaura")).setExecutor(cultPassiveCommandExecutor);
         Objects.requireNonNull(getCommand("qifly")).setExecutor(cultPassiveCommandExecutor);
+        Objects.requireNonNull(getCommand("manaccept")).setExecutor(cultPassiveCommandExecutor);
 
         OperatorCommands operatorCommands = new OperatorCommands();
         Objects.requireNonNull(getCommand("addstage")).setExecutor(operatorCommands);
@@ -142,7 +148,10 @@ public final class XianxiaCraft extends JavaPlugin {
         manualManager.saveManualData();
         qiManager.saveQiData();
 
-
+        if (adventure != null) {
+            adventure.close();
+            adventure = null;
+        }
 
         Bukkit.getScheduler().cancelTasks(this);
     }
@@ -291,6 +300,12 @@ public final class XianxiaCraft extends JavaPlugin {
                 qiAuraParticleEffect(player);
             }
         }
+    }
+
+
+
+    public static BukkitAudiences getAdventure() {
+        return adventure;
     }
 
 }

--- a/xianxiacraft/xianxiacraft/commands/CultPassiveCommandExecutor.java
+++ b/xianxiacraft/xianxiacraft/commands/CultPassiveCommandExecutor.java
@@ -7,6 +7,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import xianxiacraft.xianxiacraft.QiManagers.ManualManager;
 import xianxiacraft.xianxiacraft.QiManagers.TechniqueManager;
 
 import static xianxiacraft.xianxiacraft.QiManagers.ManualManager.getManual;
@@ -189,6 +190,13 @@ public class CultPassiveCommandExecutor implements CommandExecutor {
             TechniqueManager.setFlyBool(sender,!currentFlyBool);
 
             return true;
+        }
+
+        //accept manual
+        if(command.getName().equalsIgnoreCase("manaccept")){
+
+            ManualManager.accept(sender);
+
         }
 
 

--- a/xianxiacraft/xianxiacraft/util/ChatUtils.java
+++ b/xianxiacraft/xianxiacraft/util/ChatUtils.java
@@ -1,0 +1,19 @@
+package xianxiacraft.xianxiacraft.util;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.event.player.PlayerInteractEvent;
+import xianxiacraft.xianxiacraft.XianxiaCraft;
+
+public class ChatUtils {
+
+    public static void handleManualChange(PlayerInteractEvent e) {
+        TextComponent msg = Component.text("Click ")
+                .append(Component.text("accept",NamedTextColor.GREEN).clickEvent(ClickEvent.runCommand("/xianxiacraft:manaccept")))
+                .append(Component.text(" to cultivate this manual"));
+        XianxiaCraft.getAdventure().sender(e.getPlayer()).sendMessage(msg);
+    }
+
+
+}


### PR DESCRIPTION
Added confirmation to using manuals, discovered bug that certain events are called more than once when not selecting a block.

Added 2 dependencies and 1 new command

put in pom.xml:
      <dependency>
          <groupId>net.kyori</groupId>
          <artifactId>adventure-api</artifactId>
          <version>4.16.0</version>
      </dependency>
      <dependency>
          <groupId>net.kyori</groupId>
          <artifactId>adventure-platform-bukkit</artifactId>
          <version>4.3.2</version>
      </dependency>

put in commands in plugin.yml:
manaccept: